### PR TITLE
sort of fixed the issue, but this really isn't a good example

### DIFF
--- a/src/main/java/com/acme/Launcher.java
+++ b/src/main/java/com/acme/Launcher.java
@@ -80,10 +80,7 @@ public class Launcher {
   private static void rxBroadcast(Context context, OrderedBroadcastExecutor executor) {
     context.reset();
     fromBroadcast(context, highPriorityReceiverFilter, v -> v.abortBroadcast())
-        .doOnNext(v -> {
-          System.out.println("Received by highest priority receiver");
-          throw new RuntimeException("Intentional exception");
-        }).subscribe();
+        .subscribe(v -> System.out.println("Received by highest priority receiver"));
     fromBroadcast(context, lowPriorityReceiverFilter, v -> {})
         .doOnNext(v -> System.out.println("Cascaded till lowest priority receiver")).subscribe();
 

--- a/src/main/java/com/acme/rx/RxBroadcast.java
+++ b/src/main/java/com/acme/rx/RxBroadcast.java
@@ -21,6 +21,7 @@ public class RxBroadcast {
         public void handle(Intent intent) {
           subscriber.onNext(new Intent());
           proxyConsumer.accept(new BroadcastReceiverProxy(this));
+          throw new RuntimeException("Intentional exception");
         }
       };
       context.subscribe(receiver, filter);


### PR DESCRIPTION
I think there are a few issues going on here. I also this this is way outside the scope of the library and more of a question about how Rx works. 

A few points....
1. by doing `doOnNext()` you are actually throwing the exception before `handle()` is actually being called. Therefore, the abort and the value in `shouldAbort` is _always_ false.
2. This is way outside the scope of RxBroadcast, your are throwing errors outside of the library, it shouldn't be aware of them and/or expose it's implementation. 
3. The update I am attaching here tries to map as closely as possible to what is happening in the RxBroadcast library. It does show that it is properly working-- in my opinion. 

So hopefully I've convinced you. I think my main point is that you are killing the stream before it even really gets to the library. I do see your other example of pairing the intent with the proxy "works", but in my opinion that is not the proper way to handle this issue, it also adds to the complexity of the library (for the user) and makes things needlessly more complicated. I also think it is more of a coincidence than actually doing what you intend. With closer inspection it is a much different pattern than `fromBroadcast` as far as the work being done and gives you misguided confidence in your approach. 
